### PR TITLE
Add controller communication test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Zteam
 zteam
+
+## Tests
+
+Les tests unitaires vérifient la communication entre le contrôleur et les WebViews `zteam` et `test`.
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -4,14 +4,18 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-	"start": "electron ."
+    "test": "mocha",
+    "start": "electron ."
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "electron": "^37.2.0"
+    "chai": "^5.2.0",
+    "electron": "^37.2.0",
+    "mocha": "^11.7.1",
+    "proxyquire": "^2.1.3",
+    "sinon": "^21.0.0"
   }
 }

--- a/test/controller.test.js
+++ b/test/controller.test.js
@@ -1,0 +1,66 @@
+const {expect} = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+// helper to create a fake webview object
+function fakeWebview(name) {
+  return {
+    name,
+    send: sinon.spy(),
+    getURL: () => `file:///webview/${name}/`
+  };
+}
+
+// create stubs for electron ipcMain and webContents
+function createStubs() {
+  const listeners = {};
+  const ipcMain = {
+    on: (channel, handler) => { listeners[channel] = handler; }
+  };
+  const webContents = {
+    getAllWebContents: () => stubs.webviews
+  };
+  const stubs = {ipcMain, webContents, webviews: []};
+  return {stubs, listeners};
+}
+
+function loadController(stubs) {
+  return proxyquire('../controleur.js', {
+    electron: {
+      ipcMain: stubs.ipcMain,
+      webContents: stubs.webContents
+    },
+    fs: require('fs-extra'),
+    path: require('path'),
+    crypto: require('crypto')
+  });
+}
+
+describe('controller message routing', () => {
+  it('routes messages between webviews', () => {
+    const {stubs, listeners} = createStubs();
+    // preload controller with our stubs
+    loadController(stubs);
+
+    // register two webviews
+    const event = { reply: sinon.spy() };
+    listeners['register'](event, {name: 'zteam'});
+    const zInfo = event.reply.firstCall.args[1];
+    stubs.webviews.push(fakeWebview('zteam'));
+
+    const event2 = { reply: sinon.spy() };
+    listeners['register'](event2, {name: 'test'});
+    const tInfo = event2.reply.firstCall.args[1];
+    stubs.webviews.push(fakeWebview('test'));
+
+    // route message from zteam to test
+    const routeEvent = {};
+    const msg = {from: zInfo.id, to: tInfo.id, channel: 'chat', data: 'hello'};
+    listeners['route'](routeEvent, msg);
+
+    expect(stubs.webviews[1].send.calledWith('to-webview', sinon.match.any)).to.be.true;
+    const payload = stubs.webviews[1].send.firstCall.args[1];
+    expect(payload.from).to.equal(zInfo.id);
+    expect(payload.data).to.equal('hello');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Mocha test verifying communication through `controleur.js`
- expose test instructions in README
- ignore `node_modules` for cleanliness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a710fb02c83278313161ce592a267