### PR TITLE
Fix preload modules path and enable devtools

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ function createWindow() {
     }
   });
   win.loadFile('index.html');
+  win.webContents.openDevTools();
 }
 app.whenReady().then(createWindow);
 

--- a/webview/test/preload.js
+++ b/webview/test/preload.js
@@ -1,5 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const { ModulesGestion } = require('../../mods.js');
+const { ModulesGestion } = require('../../mod.js');
 const { fsx, path, jqueryPath, WinLoad, loadOrCreateInit, readFile, writeFile } = ModulesGestion({ modulePath: __dirname });
 
 contextBridge.exposeInMainWorld('Bridge', {

--- a/webview/zteam/preload.js
+++ b/webview/zteam/preload.js
@@ -1,5 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const { ModulesGestion } = require('../../mods.js');
+const { ModulesGestion } = require('../../mod.js');
 const { fsx, path, jqueryPath, WinLoad, loadOrCreateInit, readFile, writeFile } = ModulesGestion({ modulePath: __dirname });
 
 contextBridge.exposeInMainWorld('Bridge', {


### PR DESCRIPTION
## Summary
- fix wrong path to `mod.js` in each webview's preload
- automatically open the devtools when the main window is created

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a973b99a08327976160600b0f5f0d