### PR TITLE
Refine logs and make devtools optional

### DIFF
--- a/controleur.js
+++ b/controleur.js
@@ -80,5 +80,5 @@ function routeMessage(event, msg) {
 ipcMain.on('register', register);
 ipcMain.on('route', (e, msg) => routeMessage(e, msg));
 
-log('✅ Contrôleur initialisé et en écoute');
+log('Controleur initialise et en ecoute');
 

--- a/main.js
+++ b/main.js
@@ -13,7 +13,9 @@ function createWindow() {
     }
   });
   win.loadFile('index.html');
-  win.webContents.openDevTools();
+  if (process.env.DEBUG) {
+    win.webContents.openDevTools();
+  }
 }
 app.whenReady().then(createWindow);
 


### PR DESCRIPTION
## Summary
- simplify the initialization log in `controleur.js`
- open devtools only when `DEBUG` env variable is set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a9dc3d1088327ad1b83a4721fedab